### PR TITLE
[REFACTOR] 토큰 전달을 쿠키 대신 URL 파라미터 방식으로 변경

### DIFF
--- a/src/main/java/com/kbsw/campus_hackthon/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/kbsw/campus_hackthon/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -15,6 +15,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
@@ -35,56 +37,34 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             // User의 Role이 GUEST일 경우 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
             if(oAuth2User.getRole() == Role.GUEST) {
                 String accessToken = jwtUtil.generateAccessToken(oAuth2User.getEmail());
-                
-                // HttpOnly 쿠키로 토큰 설정 (보안 향상)
-                setTokenCookie(response, "accessToken", accessToken, 15 * 60); // 15분
-                
                 response.addHeader(jwtUtil.getAccessHeader(), "Bearer " + accessToken);
-                
-                // 토큰 없이 안전하게 리다이렉트
-                response.sendRedirect(FRONTEND_URL + "?status=guest");
+
+                // 토큰을 URL 파라미터로 전달
+                String redirectUrl = FRONTEND_URL + "?accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
+                response.sendRedirect(redirectUrl);
 
                 jwtUtil.sendAccessAndRefreshToken(response, accessToken, null);
             } else {
                 // 로그인에 성공한 경우 access, refresh 토큰 생성
                 String accessToken = jwtUtil.generateAccessToken(oAuth2User.getEmail());
                 String refreshToken = jwtUtil.generateRefreshToken(oAuth2User.getEmail());
-                
-                // HttpOnly 쿠키로 토큰 설정 (보안 향상)
-                setTokenCookie(response, "accessToken", accessToken, 15 * 60); // 15분
-                setTokenCookie(response, "refreshToken", refreshToken, 7 * 24 * 60 * 60); // 7일
-                
+
                 response.addHeader(jwtUtil.getAccessHeader(), "Bearer " + accessToken);
                 response.addHeader(jwtUtil.getRefreshHeader(), "Bearer " + refreshToken);
-                
+
+                // 토큰을 URL 파라미터로 전달
+                String redirectUrl = FRONTEND_URL +
+                        "?accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8) +
+                        "&refreshToken=" + URLEncoder.encode(refreshToken, StandardCharsets.UTF_8);
+
                 jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
                 jwtUtil.updateRefreshTokenOAuth2(oAuth2User.getEmail(), refreshToken);
-                
-                // 토큰 없이 안전하게 리다이렉트
-                response.sendRedirect(FRONTEND_URL + "?status=success");
+
+                response.sendRedirect(redirectUrl);
             }
         } catch (Exception e) {
             log.error("OAuth2 로그인 처리 중 오류 발생: {}", e.getMessage());
             response.sendRedirect(FRONTEND_URL + "/login?error=true");
         }
-    }
-    
-    /**
-     * HttpOnly 쿠키 설정 메서드 (보안 강화)
-     * @param response HTTP 응답 객체
-     * @param name 쿠키 이름
-     * @param value 쿠키 값 (토큰)
-     * @param maxAge 쿠키 만료 시간 (초)
-     */
-    private void setTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setHttpOnly(true);  // XSS 공격 방지
-        cookie.setSecure(false);   // 개발환경(HTTP)에서는 false, 운영환경(HTTPS)에서는 true로 변경
-        cookie.setPath("/");       // 모든 경로에서 접근 가능
-        cookie.setMaxAge(maxAge);  // 쿠키 만료 시간 설정
-        // cookie.setSameSite("Strict"); // CSRF 방지 (Servlet 5.0+에서 지원)
-        
-        response.addCookie(cookie);
-        log.info("HttpOnly 쿠키 설정 완료: {}", name);
     }
 }


### PR DESCRIPTION
React와 원활한 통합을 위해 URL 파라미터 형식으로 전달하는 것으로 변경함